### PR TITLE
honeymarker: omit empty datetime fields on req

### DIFF
--- a/marker.go
+++ b/marker.go
@@ -4,10 +4,10 @@ import "time"
 
 // The marker type, as described by https://honeycomb.io/docs/reference/api/#markers
 type marker struct {
-	ID string `json:"id"`
+	ID string `json:"id,omitempty"`
 
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 
 	// StartTime unix timestamp truncates to seconds
 	StartTime int64 `json:"start_time,omitempty"`


### PR DESCRIPTION
Notes

Before:
```
# body
{"created_at":"0001-01-01T00:00:00Z","updated_at":"0001-01-01T00:00:00Z","type":"deploy"}
{"error":"unexpected field \"created_at\""}
422
```

After
```
# body
{"type":"deploy"}
201
```